### PR TITLE
Update our fork of laravel-prometheus-exporter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.5 - 2020-03-16
+
+* Update call to array_get helper to use the Illuminate\Support\Arr class
+* Enable Laravel 7 compatability
+
 ## 1.0.4 - 2019-10-17
 
 * Enable Laravel 6.0 compatability

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.4 - 2019-10-17
+
+* Enable Laravel 6.0 compatability
+
 ## 1.0.3 - 2019-02-11
 
 * Enable package discovery for laravel 5.5+ 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.3 - 2019-02-11
+
+* Enable package discovery for laravel 5.5+ 
+
 ## 1.0.2 - 2019-01-16
 
 * Add compatability with Laravel Lumen (make named route configurable)

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
   ],
   "require": {
     "php": ">=5.6.0",
-    "illuminate/support": "^5.3 || ^6.0 || ^7.0",
-    "illuminate/routing": "^5.3 || ^6.0 || ^7.0",
+    "illuminate/support": "^5.3 || ^6.0 || ^7.0 || ^8.0",
+    "illuminate/routing": "^5.3 || ^6.0 || ^7.0 || ^8.0",
     "jimdo/prometheus_client_php": "^0.9.0"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,14 @@
   "extra": {
     "branch-alias": {
       "dev-master": "1.0-dev"
+    },
+    "laravel": {
+      "providers": [
+        "Superbalist\\LaravelPrometheusExporter\\PrometheusServiceProvider"
+      ],
+      "aliases": {
+        "Prometheus": "Superbalist\\LaravelPrometheusExporter\\PrometheusFacade"
+      }
     }
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
   ],
   "require": {
     "php": ">=5.6.0",
-    "illuminate/support": "^5.3 || ^6.0",
-    "illuminate/routing": "^5.3 || ^6.0",
+    "illuminate/support": "^5.3 || ^6.0 || ^7.0",
+    "illuminate/routing": "^5.3 || ^6.0 || ^7.0",
     "jimdo/prometheus_client_php": "^0.9.0"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
   ],
   "require": {
     "php": ">=5.6.0",
-    "illuminate/support": "^5.3",
-    "illuminate/routing": "^5.3",
+    "illuminate/support": "^5.3 || ^6.0",
+    "illuminate/routing": "^5.3 || ^6.0",
     "jimdo/prometheus_client_php": "^0.9.0"
   },
   "autoload": {

--- a/src/PrometheusServiceProvider.php
+++ b/src/PrometheusServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Superbalist\LaravelPrometheusExporter;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider;
 use Prometheus\CollectorRegistry;
 use Prometheus\Storage\Adapter;
@@ -50,7 +51,7 @@ class PrometheusServiceProvider extends ServiceProvider
             $factory = $app['prometheus.storage_adapter_factory']; /** @var StorageAdapterFactory $factory */
             $driver = config('prometheus.storage_adapter');
             $configs = config('prometheus.storage_adapters');
-            $config = array_get($configs, $driver, []);
+            $config = Arr::get($configs, $driver, []);
             return $factory->make($driver, $config);
         });
         $this->app->alias(Adapter::class, 'prometheus.storage_adapter');


### PR DESCRIPTION
They added laravel-8 support in October 2020 but haven't created a new release since

this is needed to eventually put soundwave on laravel 8